### PR TITLE
Conditionally run menuState.js

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -262,9 +262,6 @@ $wgVirtualRestConfig['modules']['parsoid'] = [
     'url' => "http://mediawiki-web:8080" . $wgScriptPath . '/rest.php',
 ];
 
-// Show sidebar for anonymous users;
-$wgVectorDefaultSidebarVisibleForAnonymousUser = true;
-
 // Show new sidebar table of contents.
 $wgVectorTableOfContents = [
 	"default" => true,

--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 const BASE_URL = 'http://mediawiki-web:8080';
 const tests = [
 	{
-		label: 'Main_Page (##vector-2022)',
+		label: 'Main_Page (#vector-2022)',
 		path: '/wiki/Main_Page'
 	},
 	{
@@ -19,7 +19,7 @@ const tests = [
 		misMatchThreshold: 0.04
 	},
 	{
-		label: 'Special:RecentChanges (no max width, #sidebar-closed)',
+		label: 'Special:RecentChanges (#vector-2022, no max width, #sidebar-closed)',
 		path: '/wiki/Special:RecentChanges'
 	},
 	{
@@ -35,23 +35,23 @@ const tests = [
 		path: '/wiki/Tree'
 	},
 	{
-		label: 'Main_Page (vector)',
+		label: 'Main_Page (#vector)',
 		path: '/wiki/Main_Page?useskin=vector'
 	},
 	{
-		label: 'Test (vector)',
+		label: 'Test (#vector)',
 		path: '/wiki/Test?useskin=vector'
 	},
 	{
-		label: 'Test?action=History (vector)',
+		label: 'Test?action=History (#vector)',
 		path: '/w/index.php?title=Test&action=history&useskin=vector'
 	},
 	{
-		label: 'Talk:Test (vector)',
+		label: 'Talk:Test (#vector)',
 		path: '/wiki/Talk:Test'
 	},
 	{
-		label: 'Tree (vector)',
+		label: 'Tree (#vector)',
 		path: '/wiki/Tree?useskin=vector'
 	}
 ];

--- a/src/engine-scripts/puppet/sidebarState.js
+++ b/src/engine-scripts/puppet/sidebarState.js
@@ -1,5 +1,11 @@
 const menuState = require( './menuState' );
 module.exports = async ( page, hashtags ) => {
-	const isClosed = !hashtags.includes( '#sidebar-open' );
+	const isOpen = hashtags.includes( '#sidebar-open' );
+	const isClosed = hashtags.includes( '#sidebar-closed' );
+
+	if ( !isOpen && !isClosed ) {
+		return;
+	}
+
 	await menuState( page, '#mw-sidebar-button', isClosed );
 };

--- a/src/engine-scripts/puppet/userMenuState.js
+++ b/src/engine-scripts/puppet/userMenuState.js
@@ -1,5 +1,11 @@
 const menuState = require( './menuState' );
 module.exports = async ( page, hashtags ) => {
-	const isClosed = !hashtags.includes( '#userMenu-open' );
+	const isOpen = hashtags.includes( '#userMenu-open' );
+	const isClosed = hashtags.includes( '#userMenu-closed' );
+
+	if ( !isOpen && !isClosed ) {
+		return;
+	}
+
 	await menuState( page, '#p-personal-checkbox', isClosed );
 };


### PR DESCRIPTION
The `page.waitForTimeout` was running for tests that didn't have a
relevant hash tag. Conditionally run these states based on whether they
have an explicit hash tag to speed up the tests.