### PR TITLE
Use PascalCase case for class-based files

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -3,7 +3,7 @@ const util = require( 'util' );
 const exec = util.promisify( require( 'child_process' ).exec );
 const LATEST_RELEASE_BRANCH = 'latest-release';
 const MAIN_BRANCH = 'master';
-const BatchSpawn = require( './src/batchSpawn' );
+const BatchSpawn = require( './src/BatchSpawn' );
 const batchSpawn = new BatchSpawn( 1 );
 
 /**

--- a/src/batchSpawn.test.js
+++ b/src/batchSpawn.test.js
@@ -1,4 +1,4 @@
-const BatchSpawn = require( './batchSpawn' );
+const BatchSpawn = require( './BatchSpawn' );
 const childProcess = require( 'child_process' );
 
 jest.mock( 'child_process', () => {
@@ -8,7 +8,7 @@ jest.mock( 'child_process', () => {
 	};
 } );
 
-describe( 'batchSpawn.js', () => {
+describe( 'BatchSpawn.js', () => {
 	afterEach( () => {
 		/** @type {jest.Mock} */ ( childProcess.spawn ).mockReset();
 	} );


### PR DESCRIPTION
BatchSpawn is a class with a constructor so use PascalCase to follow the
convention used in other codebases like Minerva. Files that are not class based (e.g. that export a function) can remain in camelCase