### PR TITLE
Execute git fetch before checking the list of branches

### DIFF
--- a/src/checkoutBranch.js
+++ b/src/checkoutBranch.js
@@ -45,7 +45,6 @@ function execUpdateCommand( branch, path ) {
 	return createSpawn(
 		`
 		echo "Git checkout: ${path}"
-		git -C "${path}" fetch origin
 		git -C "${path}" checkout -f ${branch}
 
 		if [ ! -e "${path}/composer.json" ]; then 
@@ -84,7 +83,7 @@ async function update( branch, repos ) {
 
 	await Promise.all( Object.keys( repos ).map( async ( id ) => {
 		const path = repos[ id ].path;
-		const childProcess = await exec( `git -C ${path} for-each-ref refs/remotes/origin/ --format='%(refname:short)'` );
+		const childProcess = await exec( `git -C ${path} fetch origin && git -C ${path} for-each-ref refs/remotes/origin/ --format='%(refname:short)'` );
 		const branches = childProcess.stdout.split( '\n' );
 
 		if ( branches.includes( branch ) ) {


### PR DESCRIPTION
I noticed that running `./pixel.js reference -b latest-release` after
not using pixel for awhile gave me lots of `Branch
"origin/wmf/1.39.0-wmf.10" of ... not found on origin` as the latest
release branch hadn't been pulled down yet.

To fix this, always run git fetch before running the command to get the
list of branches on the origin.