### PR TITLE
Do not use Special:RecentChanges to test max width

### DIFF
--- a/config.js
+++ b/config.js
@@ -18,7 +18,7 @@ const tests = [
 	},
 	{
 		label: 'Special:RecentChanges (#vector-2022, no max width, #sidebar-closed)',
-		path: '/wiki/Special:RecentChanges'
+		path: '/wiki/Special:SpecialPages'
 	},
 	{
 		label: 'Special:BlankPage with user menu open (#vector-2022, #logged-in, #userMenu-open)',


### PR DESCRIPTION
Recent changes is dynamic so any local edit on the wiki can
break the regression test.

Use Special:SpecialPages instead.