### PR TITLE
Increase default mismatch tolerance

### DIFF
--- a/config.js
+++ b/config.js
@@ -67,7 +67,7 @@ const scenarios = tests.map( ( test ) => {
 	return Object.assign( {}, test, {
 		url: `${BASE_URL}${test.path}`,
 		delay: 1500,
-		misMatchThreshold: 0.04
+		misMatchThreshold: 0.2
 	} );
 } );
 


### PR DESCRIPTION
For specific tests we can lower this again, but this will save us a lot of time getting pixel perfect.

Comparing https://gerrit.wikimedia.org/r/c/mediawiki/skins/Vector/+/787562 with current master I get 0 failures with a tolerance of 0.2 but 6 failures with the current default.