### PR TITLE
Apply 1500ms delay to vector (and not vector-2022) only

### DIFF
--- a/config.js
+++ b/config.js
@@ -43,22 +43,27 @@ const tests = [
 	},
 	{
 		label: 'Main_Page (#vector)',
+		delay: 1500,
 		path: '/wiki/Main_Page?useskin=vector'
 	},
 	{
 		label: 'Test (#vector)',
+		delay: 1500,
 		path: '/wiki/Test?useskin=vector'
 	},
 	{
 		label: 'Test?action=History (#vector)',
+		delay: 1500,
 		path: '/w/index.php?title=Test&action=history&useskin=vector'
 	},
 	{
 		label: 'Talk:Test (#vector)',
+		delay: 1500,
 		path: '/wiki/Talk:Test'
 	},
 	{
 		label: 'Tree (#vector)',
+		delay: 1500,
 		path: '/wiki/Tree?useskin=vector'
 	}
 ];
@@ -66,7 +71,6 @@ const tests = [
 const scenarios = tests.map( ( test ) => {
 	return Object.assign( {}, test, {
 		url: `${BASE_URL}${test.path}`,
-		delay: 1500,
 		misMatchThreshold: 0.04
 	} );
 } );


### PR DESCRIPTION
AFAICT the dancing tab issue in vector-2022 has been fixed as a result
of the great work done in T306229. As a result, we can speed up the
vector-2022 tests by removing the delay.

legacy vector tabs continue to dance so we keep the delay for those
tests for now.