### PR TITLE
Add ability to release Pixel as npm package with its associated Docker images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,6 @@
 node_modules
 npm-debug.log
+.git
+.github
+coverage
+backups

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,4 @@
-report
+pixel-report
 package-lock.json
 coverage
 context.json

--- a/.github/workflows/_lint-build-test.yml
+++ b/.github/workflows/_lint-build-test.yml
@@ -1,13 +1,13 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+name: Lint, Build, Test
 
-name: Push or PR workflow
-
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: 
+  workflow_call:
+    inputs:
+      run_vr:
+        required: false
+        type: boolean
+        description: Whether or not the vr tests should run.
+        default: true
 
 jobs:
   build:
@@ -27,6 +27,7 @@ jobs:
     - name: Run tests
       run: npm test
     - name: Run visual regression
+      if: ${{ inputs.run_vr == true }}
       shell: 'script -q -e -c "bash {0}"'
       run: |
         script -e -c "./pixel.js reference && ./pixel.js test"

--- a/.github/workflows/_publish-docker.yml
+++ b/.github/workflows/_publish-docker.yml
@@ -1,0 +1,48 @@
+name: Create and publish Docker images
+
+on: 
+  workflow_call:
+    inputs:
+      tag_name: 
+        required: true
+        type: string
+        description: Name of tag
+      matrix: 
+        required: true
+        type: string
+        description: Matrix JSON string that includes dockerfile and image properties.
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{fromJson(inputs.matrix)}}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: get-npm-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@main
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ghcr.io/${{matrix.image}}:${{ steps.package-version.outputs.current-version}}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,17 @@
+name: Push or PR workflow
+
+on:
+  push:
+    tags-ignore:
+      - 'v*'
+  pull_request:
+    branches: 
+      - main
+
+concurrency:
+  group: ci-pr-${{ github.ref }}-1
+  cancel-in-progress: true
+
+jobs:
+  call-lint-build-test:
+    uses: ./.github/workflows/_lint-build-test.yml

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,35 @@
+name: Tag workflow
+
+on:
+  push:
+    tags: 
+      - v*
+
+concurrency:
+  group: ci-tag-${{ github.ref }}-1
+  cancel-in-progress: true
+
+jobs:
+  call-lint-build-test:
+    uses: ./.github/workflows/_lint-build-test.yml
+    with:
+      run_vr: false
+  call-publish-npm:
+    needs: call-lint-build-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+  call-publish-docker:
+    needs: call-publish-npm
+    uses: ./.github/workflows/_publish-docker.yml
+    with:
+      tag_name: ${{ needs.call-publish-npm.outputs.version }}-next.${{ github.sha }}
+      matrix: "{\"include\":[{\"dockerfile\":\"Dockerfile.mediawiki\",\"image\":\"nicholasray/pixel_mediawiki\"},{\"dockerfile\":\"Dockerfile.database\",\"image\":\"nicholasray/pixel_database\"},{\"dockerfile\":\"Dockerfile.visual-regression\",\"image\":\"nicholasray/pixel_visual-regression\"},{\"dockerfile\":\"Dockerfile.visual-regression-reporter\",\"image\":\"nicholasray/pixel_visual-regression-reporter\"}]}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # git-deploy status file:
 /.deploy
-/context.json
 
 # Editors
 *.kate-swp
@@ -46,6 +45,8 @@ Thumbs.db
 # VSCode
 .vscode
 
-# Database tar and backups
+# Project stuff
 database.tar.gz
 backups
+pixel-report
+context.json

--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -1,3 +1,13 @@
 FROM mariadb:10.6.7
 
-RUN apt-get update && apt-get install curl -y
+COPY src/seedDb.sh /docker-entrypoint-initdb.d/
+
+ARG database="database_2022-05-05_14-29-49-0600(MDT).tar.gz"
+
+RUN apt-get update && apt-get install -y \
+	curl \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& mkdir -p /var/lib/mysql_backup \
+	&& curl -SL "https://nicholasray.github.io/pixel-seed-data/$database" \
+	| tar -C /var/lib/mysql_backup --strip-components=3 -xzv \
+	&& chown mysql:mysql /var/lib/mysql_backup

--- a/Dockerfile.mediawiki
+++ b/Dockerfile.mediawiki
@@ -1,15 +1,28 @@
 FROM node:16.15.0-buster AS node
 FROM docker-registry.wikimedia.org/dev/buster-php72-fpm:2.0.0-s1
 
-COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
-COPY --from=node /usr/local/bin/node /usr/local/bin/node
-RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
-
-COPY src /src
-COPY repositories.json /repositories.json
+COPY --from=node /usr/lib /usr/lib
+COPY --from=node /usr/local/share /usr/local/share
+COPY --from=node /usr/local/lib /usr/local/lib
+COPY --from=node /usr/local/include /usr/local/include
+COPY --from=node /usr/local/bin /usr/local/bin
 
 WORKDIR /var/www/html/w
 
 RUN git config --global user.email "app@example.com" && git config --global user.name "app"
-
+COPY repositories.json /repositories.json
+COPY src /src
 RUN /src/setupRepos.js "$( cat /repositories.json )"
+
+RUN apt-get update && apt-get install -y \
+	libfcgi-bin \
+	&& rm -rf /var/lib/apt/lists/*
+# Enable the php-fpm status page so we can do healthchecks with cgi-fcgi.
+RUN echo "pm.status_path = /status" >> /etc/php/7.2/fpm/pool.d/www.conf
+RUN curl \
+	https://raw.githubusercontent.com/renatomefi/php-fpm-healthcheck/master/php-fpm-healthcheck \
+	-o /usr/local/bin/php-fpm-healthcheck \
+	&& chmod +x /usr/local/bin/php-fpm-healthcheck
+
+COPY LocalSettings.php  /var/www/html/w/LocalSettings.php
+

--- a/Dockerfile.visual-regression
+++ b/Dockerfile.visual-regression
@@ -1,0 +1,9 @@
+FROM backstopjs/backstopjs:6.0.4
+
+COPY /src /pixel/src
+COPY /config*.js /pixel/
+WORKDIR /pixel
+
+ENV NODE_PATH=/usr/local/lib/node_modules
+
+ENTRYPOINT ["/pixel/src/runTests.js"]

--- a/Dockerfile.visual-regression-reporter
+++ b/Dockerfile.visual-regression-reporter
@@ -1,0 +1,9 @@
+FROM node:16.15.0-buster AS node
+
+RUN npm i -g http-server
+
+EXPOSE 4000
+
+WORKDIR /vrdata/pixel-report
+
+ENTRYPOINT ["http-server", "/vrdata/pixel-report", "-p", "4000", "-c-1"]

--- a/README.md
+++ b/README.md
@@ -18,22 +18,17 @@ the tool.
 
 ## Quick Start
 
-First, clone the repo wherever you wish and `cd` into it:
+Install Pixel from npm using Node 15 or later.
 
 ```sh
-git clone https://github.com/nicholasray/pixel.git && cd pixel
+npm i -g @nicholasray/pixel
 ```
 
-Pixel runs in multiple Docker containers to eliminate inconsistent rendering
-issues across environments and also to make local installation a breeze. Please
-install [Docker](https://docs.docker.com/get-docker/) and **make sure it is
-running** prior to using Pixel.
-
-Finally, install the CLI dependency:
-
-```sh
-npm install
-```
+Install [Docker](https://docs.docker.com/get-docker/) and [Docker
+Compose](https://docs.docker.com/compose/install/) and make sure Docker is
+running.  Pixel runs in multiple Docker containers to eliminate inconsistent
+rendering issues across environments and to make it easier to replicate any
+issue locally.
 
 ## Usage
 
@@ -46,94 +41,75 @@ core and all of its installed extensions and skins and then take reference
 screenshots that your test screenshots (step 2) will be compared against, then:
 
 ```sh
-./pixel.js reference
-
+pixel reference
 ```
 
 Or if you want the reference to be the latest release branch:
 
 ```sh
-./pixel.js reference -b latest-release
+pixel reference -b latest-release
 ```
 
 Or if you want the reference to be a certain release branch:
 
 ```sh
-./pixel.js reference -b origin/wmf/1.37.0-wmf.19
+pixel reference -b origin/wmf/1.39.0-wmf.12
 ```
 
-If you want to run the mobile visual regression test suite pass the `--group mobile` flag.
+The `desktop` tests run by default. If you want to run the mobile visual
+regression test suite pass the `--group mobile` flag.
 
 ### 2) Take test screenshots with changed code
 
-If you want to pull a change or multiple changes down from gerrit, take screenshots with these changes on top of master and then compare these screenshots against the reference screenshots, then
+If you want to pull a change or multiple changes down from gerrit, take
+screenshots with these changes on top of master and then compare these
+screenshots against the reference screenshots, then
 
 ```sh
-./pixel.js test -c Iff231a976c473217b0fa4da1aa9a8d1c2a1a19f2
+pixel test -c Iff231a976c473217b0fa4da1aa9a8d1c2a1a19f2
 ```
 
 Note that although change id `Iff231a976c473217b0fa4da1aa9a8d1c2a1a19f2` has a
 `Depends-On` dependency, it is the only change that needs to be passed. Pixel
 will figure out and pull down the rest of the dependencies provided that it has
-the relevant repositories (set in repositories.json).
+the relevant repositories (set in [repositories.json](repositories.json)).
+
+Similar to the `reference` command, the `desktop` tests run by default. If you
+want to run the mobile visual regression test suite pass the `--group mobile`
+flag.
 
 An HTML report of your test results with screenshots will be opened
-automatically on a Mac after the test completes. If you're not on a Mac, you can
-manually open the file at `report/index.html`.
+automatically in a browser on a Mac after the test completes. If you're not on a
+Mac, you can manually open the report at `http://localhost:4000`. Additionally,
+if you want to save the report to a file path, you can do so with the `--output`
+flag:
 
-Additionally, Pixel runs a server at `http://localhost:3000` (default) which can
-be used to interact with/debug the same server that the tests use.
+```sh
+pixel test -c <change-id> --output <path-to-report>
+```
 
-If you want to run the mobile visual regression test suite pass the `--group mobile` flag.
+Pixel also runs a server at `http://localhost:3000` (default) which can be used
+to interact with/debug the same MediaWiki server that the tests use.
+
 
 ### Stopping the services
 
-If you want to stop all of Pixel's services, run:
+If you want to stop all of Pixel's containers, run:
 
 ```
-npm stop
-```
-
-### Cleanup
-
-Sometimes after making MediaWiki code changes, database changes, or having
-issues with the containers you just want to throw away everything and start
-Pixel with a clean slate. To do that, run:
-
-```
-npm run clean
-```
-
-Note that if you've made changes to LocalSettings.php and want to reset that,
-you'll also need to run:
-
-```
-git checkout -- LocalSettings.php
-```
-
-If all else fails and you're still running into problems, you may want to try removing Docker's build cache:
-
-```
-docker builder prune
+pixel stop
 ```
 
 ## Development
 
 ### Changing or adding tests
 
-All tests are located in [config.js](config.js) and follow
-BackstopJS conventions. For more info on how to change or add tests, please
-refer to the [BackstopJS](https://github.com/garris/BackstopJS) README.
+Tests are located in config files at the root directory e.g.
+[configDesktop.js](configDesktop.js) and currently follow BackstopJS
+conventions. For more info on how to change or add tests, please refer to the
+[BackstopJS](https://github.com/garris/BackstopJS) README.
 
 Scenarios for mobile site are defined in configMobile.js.
-
-### Configuring MediaWiki
-
-All mediawiki config is in [LocalSettings.php](LocalSettings.php) and can be
-changed. For example, maybe you are working on a new feature in the `Vector`
-skin that is feature flagged and want to enable it. All changes made in this
-file will be automatically reflected in the Docker services without having to
-restart them.
 
 ### Installed extensions and skins
 

--- a/configDesktop.js
+++ b/configDesktop.js
@@ -1,3 +1,4 @@
+const configFactory = require( './configFactory' );
 const BASE_URL = process.env.MW_SERVER;
 const tests = [
 	{
@@ -75,56 +76,4 @@ const scenarios = tests.map( ( test ) => {
 	} );
 } );
 
-module.exports = {
-	id: 'MediaWiki',
-	viewports: [
-		{
-			label: 'phone',
-			width: 320,
-			height: 480
-		},
-		{
-			label: 'tablet',
-			width: 720,
-			height: 768
-		},
-		{
-			label: 'desktop',
-			width: 1000,
-			height: 900
-		},
-		{
-			label: 'desktop-wide',
-			width: 1792,
-			height: 900
-		}
-	],
-	onBeforeScript: 'puppet/onBefore.js',
-	onReadyScript: 'puppet/onReady.js',
-	scenarios,
-	paths: {
-		// eslint-disable-next-line camelcase
-		bitmaps_reference: 'report/reference-screenshots',
-		// eslint-disable-next-line camelcase
-		bitmaps_test: 'report/test-screenshots',
-		// eslint-disable-next-line camelcase
-		engine_scripts: 'src/engine-scripts',
-		// eslint-disable-next-line camelcase
-		html_report: 'report/desktop',
-		// eslint-disable-next-line camelcase
-		ci_report: 'report/ci-report',
-		// eslint-disable-next-line camelcase
-		json_report: 'report/json-report'
-	},
-	report: [],
-	engine: 'puppeteer',
-	engineOptions: {
-		args: [
-			'--no-sandbox'
-		]
-	},
-	asyncCaptureLimit: 5,
-	asyncCompareLimit: 50,
-	debug: false,
-	debugWindow: false
-};
+module.exports = configFactory( 'desktop', scenarios );

--- a/configFactory.js
+++ b/configFactory.js
@@ -1,0 +1,61 @@
+const REPORT_DIR = '/vrdata/pixel-report';
+
+/**
+ * Factory function that returns Backstop config based on a name for the group
+ * of tests and a given set of scenarios.
+ *
+ * @param {string} group
+ * @param {import("backstopjs").Scenario[]} scenarios
+ * @return {import("backstopjs").Config}
+ */
+module.exports = ( group, scenarios ) => {
+	return {
+		id: group,
+		viewports: [
+			{
+				label: 'phone',
+				width: 320,
+				height: 480
+			},
+			{
+				label: 'tablet',
+				width: 720,
+				height: 768
+			},
+			{
+				label: 'desktop',
+				width: 1000,
+				height: 900
+			},
+			{
+				label: 'desktop-wide',
+				width: 1792,
+				height: 900
+			}
+		],
+		onBeforeScript: 'puppet/onBefore.js',
+		onReadyScript: 'puppet/onReady.js',
+		scenarios,
+		paths: {
+			// eslint-disable-next-line camelcase
+			bitmaps_reference: `${REPORT_DIR}/reference-screenshots-${group}`,
+			// eslint-disable-next-line camelcase
+			bitmaps_test: `${REPORT_DIR}/test-screenshots-${group}`,
+			// eslint-disable-next-line camelcase
+			engine_scripts: 'src/engine-scripts',
+			// eslint-disable-next-line camelcase
+			html_report: `${REPORT_DIR}/${group}`
+		},
+		report: [],
+		engine: 'puppeteer',
+		engineOptions: {
+			args: [
+				'--no-sandbox'
+			]
+		},
+		asyncCaptureLimit: 5,
+		asyncCompareLimit: 50,
+		debug: false,
+		debugWindow: false
+	};
+};

--- a/configMobile.js
+++ b/configMobile.js
@@ -1,5 +1,4 @@
-const config = require( './config.js' );
-
+const configFactory = require( './configFactory.js' );
 const BASE_URL = process.env.MW_SERVER;
 const tests = [
 	{
@@ -32,14 +31,4 @@ const scenarios = tests.map( ( test ) => {
 	} );
 } );
 
-module.exports = Object.assign( {}, config, {
-	scenarios,
-	paths: Object.assign( {}, config.paths, {
-		// eslint-disable-next-line camelcase
-		bitmaps_reference: 'report/reference-screenshots-mobile',
-		// eslint-disable-next-line camelcase
-		bitmaps_test: 'report/test-screenshots',
-		// eslint-disable-next-line camelcase
-		html_report: 'report/mobile'
-	} )
-} );
+module.exports = configFactory( 'mobile', scenarios );

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,16 @@
+volumes:
+  dbdata:
+    name: pixel_build_dbdata
+  mwcode:
+    name: pixel_build_mwcode
+  vrdata:
+    name: pixel_build_vrdata
+services:
+  mediawiki:
+    image: ghcr.io/nicholasray/pixel_mediawiki:0.0.0
+  database:
+    image: ghcr.io/nicholasray/pixel_database:0.0.0
+  visual-regression:
+    image: ghcr.io/nicholasray/pixel_visual-regression:0.0.0
+  visual-regression-reporter:
+    image: ghcr.io/nicholasray/pixel_visual-regression-reporter:0.0.0

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,35 @@
+volumes:
+  dbdata:
+    name: pixel_dev_dbdata
+  mwcode:
+    name: pixel_dev_mwcode
+  vrdata:
+    name: pixel_dev_vrdata
+services:
+  mediawiki:
+    image: pixel_mediawiki:0.0.0
+    build:
+      context: .
+      dockerfile: Dockerfile.mediawiki
+    volumes:
+      - ./LocalSettings.php:/var/www/html/w/LocalSettings.php
+      - ./src:/src
+  database:
+    image: pixel_database:0.0.0
+    build:
+      context: .
+      dockerfile: Dockerfile.database
+    volumes:
+      - ./src/seedDb.sh:/docker-entrypoint-initdb.d/seedDb.sh
+  visual-regression:
+    image: pixel_visual-regression:0.0.0
+    build:
+      context: .
+      dockerfile: Dockerfile.visual-regression
+    volumes:
+      - .:/pixel/
+  visual-regression-reporter:
+    image: pixel_visual-regression-reporter:0.0.0
+    build:
+      context: .
+      dockerfile: Dockerfile.visual-regression-reporter

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,59 +1,69 @@
-version: "3.8"
-
 volumes:
   dbdata:
+    labels:
+      - "@nicholasray/pixel=0.0.0"
   mwcode:
+    labels:
+      - "@nicholasray/pixel=0.0.0"
+  vrdata:
+    labels:
+      - "@nicholasray/pixel=0.0.0"
 services:
   mediawiki:
-    build:
-      context: .
-      dockerfile: Dockerfile.mediawiki
     env_file:
       - .env
     environment:
       COMPOSER_CACHE_DIR: /var/www/html/w/cache/composer
     volumes:
       - mwcode:/var/www/html/w
-      - ./LocalSettings.php:/var/www/html/w/LocalSettings.php
-      - ./src:/src
     depends_on:
       database:
         condition: service_healthy
+    healthcheck:
+      test: [ CMD, php-fpm-healthcheck ]
+      interval: 5s
+      timeout: 1s
+      retries: 10
   mediawiki-web:
-    image: docker-registry.wikimedia.org/dev/buster-apache2:1.0.0-s1
-    user: "${MW_DOCKER_UID}:${MW_DOCKER_GID}"
-    ports:
-      - "${MW_DOCKER_PORT:-8080}:8080"
+    image: docker-registry.wikimedia.org/dev/buster-apache2:2.0.0
     env_file:
       - .env
+    user: "${MW_DOCKER_UID}:${MW_DOCKER_GID}"
+    ports:
+      - "${MW_DOCKER_PORT}:8080"
     volumes:
       - mwcode:/var/www/html/w
     depends_on:
-      database:
+      mediawiki:
         condition: service_healthy
+    healthcheck:
+      test: [ CMD, curl, -f, http://localhost:8080/wiki/Main_Page ]
+      interval: 5s
+      timeout: 5s
+      retries: 10
   database:
-    build:
-      context: .
-      dockerfile: Dockerfile.database
     environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: 1
     volumes:
       - dbdata:/var/lib/mysql
-      - ./src/seedDb.sh:/docker-entrypoint-initdb.d/seedDb.sh
     healthcheck:
       test: [ CMD, mysqladmin, ping, -h, localhost ]
-      interval: 10s
+      interval: 5s
       timeout: 5s
       retries: 10
   visual-regression:
     network_mode: host
-    image: backstopjs/backstopjs:6.0.4
-    working_dir: /pixel
     env_file:
       - .env
     volumes:
-      - ./context.json:/pixel/context.json
-      - ./config.js:/pixel/config.js
-      - ./configMobile.js:/pixel/configMobile.js
-      - ./src:/pixel/src
-      - ./report:/pixel/report
+      - vrdata:/vrdata
+    depends_on:
+      mediawiki-web:
+        condition: service_healthy
+  visual-regression-reporter:
+    env_file:
+      - .env
+    ports:
+      - "4000:4000"
+    volumes:
+      - vrdata:/vrdata

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,18 @@
 {
-	"name": "pixel",
+	"name": "@nicholasray/pixel",
+	"version": "0.13.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"name": "pixel",
+			"name": "@nicholasray/pixel",
+			"version": "0.13.0",
+			"license": "MIT",
 			"dependencies": {
 				"commander": "^9.1.0"
+			},
+			"bin": {
+				"pixel": "pixel.js"
 			},
 			"devDependencies": {
 				"@types/backstopjs": "^4.1.2",
@@ -20,7 +26,7 @@
 				"typescript": "^4.6.3"
 			},
 			"engines": {
-				"node": ">=16",
+				"node": ">=15",
 				"npm": ">=7.21.0"
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,29 @@
 {
-	"private": true,
-	"name": "pixel",
+	"name": "@nicholasray/pixel",
+	"version": "0.0.0",
+	"description": "Catch visual regressions in MediaWiki before users see them",
+	"license": "GPL-2.0-or-later",
+	"bin": {
+		"pixel": "./pixel.js"
+	},
+	"files": [
+		"src",
+		"config*.js",
+		"docker-compose.yml",
+		"docker-compose.build.yml",
+		"pixel.js",
+		".env"
+	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/nicholasray/pixel.git"
+	},
+	"keywords": [
+		"visual regression",
+		"visual tests",
+		"visual diff",
+		"ui tests"
+	],
 	"scripts": {
 		"start": "docker compose up -d",
 		"stop": "docker compose down",
@@ -14,7 +37,7 @@
 	},
 	"engines": {
 		"npm": ">=7.21.0",
-		"node": ">=16"
+		"node": ">=15"
 	},
 	"pre-commit": "pre-commit",
 	"devDependencies": {

--- a/pixel.js
+++ b/pixel.js
@@ -3,20 +3,24 @@ const util = require( 'util' );
 const exec = util.promisify( require( 'child_process' ).exec );
 const LATEST_RELEASE_BRANCH = 'latest-release';
 const MAIN_BRANCH = 'master';
+const SERVICES = [
+	'mediawiki',
+	'database',
+	'visual-regression',
+	'visual-regression-reporter'
+];
 const BatchSpawn = require( './src/BatchSpawn' );
 const batchSpawn = new BatchSpawn( 1 );
+const REPORT_ORIGIN = 'http://localhost:4000';
+const packageJson = require( './package.json' );
+const { program, Option } = require( 'commander' );
+const pathResolve = require( 'path' ).resolve;
 const fs = require( 'fs' );
-const CONTEXT_PATH = `${__dirname}/context.json`;
-
-let context;
-if ( fs.existsSync( CONTEXT_PATH ) ) {
-	context = JSON.parse( fs.readFileSync( CONTEXT_PATH ).toString() );
-} else {
-	context = {
-		test: 'unknown',
-		reference: 'unknown'
-	};
-}
+// Use the presence of the package-lock.json file as a proxy for whether this
+// script is running as part of a released package. The package-lock.json file
+// is not specified in the `files` list in package.json so it will not exist in
+// releases.
+const IS_BUILD = !fs.existsSync( `${__dirname}/package-lock.json` );
 
 /**
  * @return {Promise<string>}
@@ -27,94 +31,171 @@ async function getLatestReleaseBranch() {
 }
 
 /**
- * @param {'test'|'reference'} type
- * @param {'mobile'|'desktop'} group
- * @return {Promise<undefined>}
+ * @param {string} reportLocation
  */
-async function openReportIfNecessary( type, group ) {
-	const REPORT_PATH = `report/${group}/index.html`;
-	const filePathFull = `${__dirname}/${REPORT_PATH}`;
-	const markerString = '<div id="root">';
+async function copyReportToHost( reportLocation ) {
 	try {
-		if ( type === 'reference' ) {
-			return;
-		}
-		const fileString = fs.readFileSync( filePathFull ).toString().replace(
-			markerString,
-			`<div style="color: #000; box-sizing: border-box;
-margin-bottom: 16px;border: 1px solid; padding: 12px 24px;
-word-wrap: break-word; overflow-wrap: break-word; overflow: hidden;
-background-color: #eaecf0; border-color: #a2a9b1;">
-<h2>Test group: <strong>${context.group}</strong></h2>
-<p>Comparing ${context.reference} against ${context.test}.</p>
-<p>Test ran on ${new Date()}</p>
-</div>
-${markerString}`
+		// Save report to host at the location specified by `path`.
+		await batchSpawn.spawn(
+			'docker',
+			[ 'compose', ...getComposeOpts( [ 'cp', 'visual-regression-reporter:/vrdata/pixel-report', reportLocation ] ) ]
 		);
-		fs.writeFileSync( filePathFull, fileString );
-		await batchSpawn.spawn( 'open', [ REPORT_PATH ] );
 	} catch ( e ) {
-		console.log( `Could not open report, but it is located at ${REPORT_PATH}` );
+		console.log( 'Could not copy report to host', e );
 	}
 }
 
 /**
- * @param {string} groupName
- * @return {string} path to configuration file.
- * @throws {Error} for unknown group
+ * @param {'test'|'reference'} type
+ * @param {string} group
+ * @param {string} [path] Path that the report should be written.
+ * @return {Promise<undefined>}
  */
-const getGroupConfig = ( groupName ) => {
-	switch ( groupName ) {
-		case 'desktop':
-			return 'config.js';
-		case 'mobile':
-			return 'configMobile.js';
-		default:
-			throw new Error( `Unknown test group: ${groupName}` );
+async function openReportIfNecessary( type, group, path ) {
+	const reportUrl = `${REPORT_ORIGIN}/${group}`;
+
+	try {
+		if ( type === 'reference' ) {
+			return;
+		}
+
+		if ( path ) {
+			path = pathResolve( path );
+			copyReportToHost( pathResolve( path ) );
+		}
+
+		await batchSpawn.spawn( 'open', [ reportUrl ] );
+
+		console.log( `Report located at ${reportUrl}${path ? ` and at ${path}` : ''}` );
+	} catch ( e ) {
+		console.log( `Could not open report, but it is located at ${reportUrl}` );
 	}
-};
+}
 
 /**
- * @param {'test'|'reference'} type
+ * @param {string[]} opts
+ * @return {string[]}
+ */
+function getComposeOpts( opts ) {
+	return [
+		'--project-directory', __dirname,
+		'-f', `${__dirname}/docker-compose.yml`,
+		'-f', IS_BUILD ? `${__dirname}/docker-compose.build.yml` : `${__dirname}/docker-compose.override.yml`,
+		...opts
+	];
+}
+
+/**
+ * Removes all images, containers, networks, and volumes associated with Pixel.
+ * This is mostly used if Pixel is throwing errors and you want a quick way to
+ * reset everything and start Pixel with a fresh slate.
+ *
+ * @return {Promise}
+ */
+async function cleanCommand() {
+	await Promise.all( [
+		batchSpawn.spawn( 'docker', [ 'compose', ...getComposeOpts( [ 'down', '--rmi', 'all', '--volumes', '--remove-orphans' ] ) ] ),
+		batchSpawn.spawn( 'docker', [ 'compose', ...getComposeOpts( [ '--profile', 'visual-regression', 'down', '--rmi', 'all', '--volumes', '--remove-orphans' ] ) ] ),
+		batchSpawn.spawn( 'docker', [ 'image', 'prune', '-a', '--filter', 'label=project=@nicholasray/pixel', '-f' ] )
+	] );
+}
+
+/**
+ * @param {string[]} imageTags
+ */
+async function prepareVersion( imageTags ) {
+	if ( imageTags.every( ( imageTag ) => imageTag === packageJson.version ) ) {
+		// Images match package.json version so return early.
+		return;
+	}
+
+	console.warn( `Docker images associated with ${packageJson.version} were not found. To prepare for this version, all previous data volumes, images, and containers will be removed in 5 seconds (abort with control-c)` );
+	await new Promise( ( resolve ) => {
+		setTimeout( resolve, 5000 );
+	} );
+	await cleanCommand();
+
+	if ( !IS_BUILD ) {
+		return Promise.all(
+			[
+				batchSpawn.spawn(
+					'docker',
+					[ 'compose', ...getComposeOpts( [ 'build' ] ) ]
+				),
+				batchSpawn.spawn(
+					'docker',
+					[ 'compose', ...getComposeOpts( [ '--profile', 'visual-regression', 'build' ] ) ]
+				)
+			]
+
+		);
+	}
+
+}
+
+/**
  * @param {any} opts
  */
-async function processCommand( type, opts ) {
+async function processCommand( opts ) {
 	try {
 		// Check if `-b latest-release` was used and, if so, set opts.branch to the
 		// latest release branch.
 		if ( opts.branch === LATEST_RELEASE_BRANCH ) {
 			opts.branch = await getLatestReleaseBranch();
 
-			console.log( `Using latest branch "${opts.branch}"` );
+			console.log( `Using latest release branch "${opts.branch}"` );
 		}
-		const group = opts.group;
-		context[ type ] = opts.branch;
-		context.group = group;
-		// store details of this run.
-		fs.writeFileSync( `${__dirname}/context.json`, JSON.stringify( context ) );
-		const configFile = getGroupConfig( group );
+
+		// Reset the database if `--reset-db` option is passed.
+		if ( opts.resetDb ) {
+			await batchSpawn.spawn(
+				'docker',
+				[ 'compose', ...getComposeOpts( [ 'stop', 'database' ] ) ]
+			);
+
+			await batchSpawn.spawn(
+				'docker',
+				[ 'compose', ...getComposeOpts( [ 'rm', '-f', 'database' ] ) ]
+			);
+
+			await batchSpawn.spawn(
+				'docker',
+				[ 'volume', 'rm', '-f', 'pixel_dbdata' ]
+			);
+		}
+
+		const imageTags = ( await Promise.all( SERVICES.map( async ( service ) => {
+			const imageId = ( await exec( `docker compose ${getComposeOpts( [ 'images', service, '-q' ] ).join( ' ' )}` ) ).stdout.trim();
+			return ( imageId === '' ) ? '' : ( await exec( `docker image inspect ${imageId} -f "{{index .RepoTags 0}}"` ) ).stdout.split( ':' )[ 1 ].trim();
+		} ) ) ).filter( ( imageTag ) => imageTag !== '' );
+
+		// Prepare for new version if necessary.
+		await prepareVersion( imageTags );
 
 		// Start docker containers.
-		await batchSpawn.spawn( 'docker-compose', [ 'up', '-d' ] );
+		await batchSpawn.spawn(
+			'docker',
+			[ 'compose', ...getComposeOpts( [ 'up', '-d', '--quiet-pull' ] ) ]
+		);
 		// Execute main.js.
 		await batchSpawn.spawn(
-			'docker-compose',
-			[ 'exec', '-T', 'mediawiki', '/src/main.js', JSON.stringify( opts ) ]
+			'docker',
+			[ 'compose', ...getComposeOpts( [ 'exec', '-T', 'mediawiki', '/src/main.js', JSON.stringify( opts ) ] ) ]
 		);
 		// Execute Visual regression tests.
 		await batchSpawn.spawn(
-			'docker-compose',
-			[ 'run', '--rm', 'visual-regression', type, '--config', configFile ]
+			'docker',
+			[ 'compose', ...getComposeOpts( [ '--profile', 'visual-regression', 'run', '--rm', 'visual-regression', JSON.stringify( opts ) ] ) ]
 		).then( async () => {
-			await openReportIfNecessary( type, group );
+			await openReportIfNecessary( opts.type, opts.group, opts.output );
 		}, async ( /** @type {Error} */ err ) => {
 			if ( err.message.includes( '130' ) ) {
 				// If user ends subprocess with a sigint, exit early.
 				return;
 			}
 
-			if ( err.message.includes( 'Exit with error code 1' ) ) {
-				return openReportIfNecessary( type, group );
+			if ( err.message === 'Exit with error code 1' ) {
+				return openReportIfNecessary( opts.type, opts.group, opts.output );
 			}
 
 			throw err;
@@ -127,24 +208,31 @@ async function processCommand( type, opts ) {
 }
 
 function setupCli() {
-	const { program } = require( 'commander' );
 	const branchOpt = /** @type {const} */ ( [
 		'-b, --branch <name-of-branch>',
-		`Name of branch. Can be "${MAIN_BRANCH}" or a release branch (e.g. "origin/wmf/1.37.0-wmf.19"). Use "${LATEST_RELEASE_BRANCH}" to use the latest wmf release branch.`,
+		`Name of branch. Can be "${MAIN_BRANCH}" or a release branch (e.g. "origin/wmf/1.39.0-wmf.10"). Use "${LATEST_RELEASE_BRANCH}" to use the latest wmf release branch.`,
 		'master'
 	] );
 	const changeIdOpt = /** @type {const} */ ( [
 		'-c, --change-id <Change-Id...>',
 		'The Change-Id to use. Use multiple flags to use multiple Change-Ids (e.g. -c <Change-Id> -c <Change-Id>)'
 	] );
-	const groupOpt = /** @type {const} */ ( [
+	const groupOpt = new Option(
 		'-g, --group <(mobile|desktop)>',
 		'The group of tests to run. If omitted the group will be desktop.',
 		'desktop'
+	)
+		.default( 'desktop' )
+		.choices( [ 'mobile', 'desktop' ] );
+
+	const resetDbOpt = /** @type {const} */ ( [
+		'--reset-db',
+		'Reset the database before running the test. This will permanently remove all data that is currently in the database.'
 	] );
 
 	program
-		.name( 'pixel.js' )
+		.name( 'pixel' )
+		.version( packageJson.version, '-v, --version', 'output the version number' )
 		.description( 'Welcome to the pixel CLI to perform visual regression testing' );
 
 	program
@@ -152,9 +240,12 @@ function setupCli() {
 		.description( 'Create reference (baseline) screenshots and delete the old reference screenshots.' )
 		.requiredOption( ...branchOpt )
 		.option( ...changeIdOpt )
-		.option( ...groupOpt )
+		.addOption( groupOpt )
+		.option( ...resetDbOpt )
 		.action( ( opts ) => {
-			processCommand( 'reference', opts );
+			opts = Object.assign( {}, opts, { type: 'reference' } );
+
+			processCommand( opts );
 		} );
 
 	program
@@ -162,9 +253,36 @@ function setupCli() {
 		.description( 'Create test screenshots and compare them against the reference screenshots.' )
 		.requiredOption( ...branchOpt )
 		.option( ...changeIdOpt )
-		.option( ...groupOpt )
+		.addOption( groupOpt )
+		.option( ...resetDbOpt )
+		.addOption(
+			new Option(
+				'-o, --output [path-to-report]',
+				'Save static report to a given path. Defaults to the current working directory.',
+				'pixel-report'
+			).preset( './pixel-report' )
+		)
 		.action( ( opts ) => {
-			processCommand( 'test', opts );
+			opts = Object.assign( {}, opts, { type: 'test' } );
+
+			processCommand( opts );
+		} );
+
+	program
+		.command( 'stop' )
+		.description( 'Stops all Docker containers associated with Pixel' )
+		.action( async () => {
+			await batchSpawn.spawn(
+				'docker',
+				[ 'compose', ...getComposeOpts( [ 'stop' ] ) ]
+			);
+		} );
+
+	program
+		.command( 'clean' )
+		.description( 'Removes all containers, images, networks, and volumes associated with Pixel so that it can start with a clean slate. If Pixel is throwing errors, try running this command.' )
+		.action( async () => {
+			await cleanCommand();
 		} );
 
 	program.parse();

--- a/report/.gitignore
+++ b/report/.gitignore
@@ -1,3 +1,0 @@
-# Ignore everything except this file
-*
-!.gitignore

--- a/src/runTests.js
+++ b/src/runTests.js
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+// eslint-disable-next-line node/no-missing-require
+const backstop = require( 'backstopjs' );
+const opts = /** @type {Opts} */ ( JSON.parse( process.argv[ 2 ] ) );
+const fs = require( 'fs' );
+const util = require( 'util' );
+const readdir = util.promisify( fs.readdir );
+const DATA_PATH = '/vrdata';
+const REPORT_DIR_PATH = `${DATA_PATH}/pixel-report`;
+const GROUP_PATH = `${REPORT_DIR_PATH}/${opts.group}`;
+const GROUP_INDEX_PATH = `${GROUP_PATH}/index.html`;
+const INDEX_PATH = `${DATA_PATH}/pixel-report/index.html`;
+const CONTEXT_PATH = `${DATA_PATH}/context.json`;
+const UNKNOWN_CONTEXT = {
+	test: 'unknown',
+	reference: 'unknown',
+	group: 'unknown'
+};
+
+/**
+ * @param {string} str
+ * @return {string} Return string in title case form e.g. ("mobile" becomes "Mobile").
+ */
+function toTitleCase( str ) {
+	return str.charAt( 0 ).toUpperCase() + str.slice( 1 );
+}
+
+const config = require( `/pixel/config${toTitleCase( opts.group )}` );
+
+/**
+ * @typedef {Object} Opts
+ * @property {'reference'|'test'} type
+ * @property {string} configPath
+ * @property {string} branch
+ * @property {string} group
+ * @property {string[]} changeId
+ */
+
+/**
+ * @typedef {Object} Context
+ * @property {string} reference
+ * @property {string} test
+ * @property {string} group
+ */
+
+/**
+ * @param {Context[]} contexts
+ * @return {string}
+ */
+function renderIndexTemplate( contexts ) {
+	return `
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>UI regression reports</title>
+		<style>
+			body {
+				margin: 0;
+				padding: 0;
+				font-family: sans-serif;
+			}
+
+			ul {
+				list-style: none;
+				margin: 0;
+				padding: 0;
+			}
+
+			a {
+				text-decoration: none;
+			}
+
+			.container {
+				max-width: 1200px;
+				margin-left: auto;
+				margin-right: auto;
+				padding-left: 24px;
+				padding-right: 24px;
+			}
+
+			.card {
+				display: flex;
+				gap: 16px;
+				align-items: center;
+				justify-content: space-between;
+				background: rgb(248, 249, 251);
+				color: rgb(17, 24, 39);
+				margin-bottom: 8px;
+				padding: 24px 16px;
+				border-radius: 8px;
+				font-size: 22px;
+			}
+
+			.tag {
+				font-size: 14px;
+				background: rgb(229 231 235);
+				color: #4d535e;
+				border-radius: 50px;
+				padding: 4px 8px;
+				white-space: nowrap;
+				text-overflow: ellipsis;
+				overflow: hidden;
+			}
+		</style>
+	</head>
+	<body>
+		<div class="container">
+			<h1>UI regression reports</h1>
+			<ul>
+				${contexts.map( ( context ) => `
+				<li>
+					<a href="${context.group}/index.html">
+						<div class="card">
+							<div>${context.group}</div>
+							<code class="tag">${context.reference} against ${context.test}</code>
+						</div>
+					</a>
+				</li>
+				` ).join( '\n' )} 
+			</ul>
+		</div>
+	</body>
+</html>`;
+}
+
+/**
+ * Writes context (date and branches used) to report.
+ *
+ * @param {Context} context
+ */
+async function prepareReportIfNecessary( context ) {
+	if ( opts.type !== 'test' ) {
+		return;
+	}
+
+	// Add message at top of group report that shows context of of the run.
+	const markerString = '<div id="root">';
+	const fileString = fs.readFileSync( GROUP_INDEX_PATH ).toString().replace(
+		markerString,
+		`<div style="color: #000; box-sizing: border-box;
+margin-bottom: 16px;border: 1px solid; padding: 12px 24px;
+word-wrap: break-word; overflow-wrap: break-word; overflow: hidden;
+background-color: #eaecf0; border-color: #a2a9b1;">
+<h2>Test group: <strong>${context.group}</strong></h2>
+<p>Comparing ${context.reference} against ${context.test}.</p>
+<p>Test ran on ${new Date()}</p>
+</div>
+${markerString}`
+	);
+	fs.writeFileSync( `${GROUP_PATH}/context.json`, JSON.stringify( context ) );
+	fs.writeFileSync( GROUP_INDEX_PATH, fileString );
+
+	// Add root index.html that shows list of reports.
+	const contexts = ( await readdir( REPORT_DIR_PATH, { withFileTypes: true } ) )
+		.filter( ( file ) => file.isDirectory() && !file.name.includes( 'screenshots' ) )
+		.map( ( dir ) => {
+			const groupPath = `${REPORT_DIR_PATH}/${dir.name}/context.json`;
+			const reportContext = JSON.parse( fs.readFileSync( groupPath ).toString() );
+
+			return {
+				name: dir.name,
+				...reportContext
+			};
+		} );
+
+	fs.writeFileSync( INDEX_PATH, renderIndexTemplate( contexts ) );
+}
+
+async function init() {
+	const /** @type {Context} */ context =
+		fs.existsSync( CONTEXT_PATH ) ?
+			JSON.parse( fs.readFileSync( CONTEXT_PATH ).toString() ) :
+			{
+				...UNKNOWN_CONTEXT
+			};
+
+	if ( opts.type === 'test' ) {
+		// Remove prior test screenshot directories to prevent them building up.
+		// Backstop already deletes reference screenshots.
+		fs.rmdirSync( config.paths.bitmaps_test, { recursive: true } );
+	}
+
+	// Save context for future use.
+	context[ opts.type ] = opts.changeId && opts.changeId.length ?
+		`${opts.branch} with ${opts.changeId.map( ( changeId ) => changeId.slice( 0, 6 ) ).join( ', ' )}` : opts.branch;
+	context.group = opts.group;
+	fs.writeFileSync( CONTEXT_PATH, JSON.stringify( context ) );
+
+	// @ts-ignore
+	await backstop( opts.type, { config } )
+		.then( () => {
+			return prepareReportIfNecessary( context );
+		} )
+		.catch( async ( /** @type {unknown} */ e ) => {
+			if ( e instanceof Error && e.message.includes( 'Mismatch errors found' ) ) {
+				await prepareReportIfNecessary( context );
+
+				// eslint-disable-next-line no-process-exit
+				process.exit( 1 );
+			}
+
+			throw e;
+		} );
+}
+
+init();

--- a/src/seedDb.sh
+++ b/src/seedDb.sh
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 
-curl "https://pixeltool.netlify.app/database_2022-05-05_14-29-49-0600(MDT).tar.gz" -o var/lib/mysql/database.tar.gz
-tar -xvf var/lib/mysql/database.tar.gz
+rsync -a /var/lib/mysql_backup/ /var/lib/mysql

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"include": [
 		"src",
-		"config.js"
+		"configDesktop.js"
 	],
 	"exclude": [
 		"src/engine-scripts",


### PR DESCRIPTION
Make npm and docker packages/images to facilitate versioning.

* Enables the ability to release pixel as an npm package with its associated docker images
* Splits docker-compose.yml into a base docker-compose.yml, docker-compose.overrides.yml for local development, and docker-compose.build.yml for releases
* Moves visual regression testing logic into its own container
* Adds configFactory that configDesktop and configMobile now use to DRY up code

