### PR TITLE
Remove prefers-reduced-motion emulation

### DIFF
--- a/src/engine-scripts/puppet/fastForwardAnimations.js
+++ b/src/engine-scripts/puppet/fastForwardAnimations.js
@@ -9,7 +9,7 @@
  * @param {import("puppeteer").Page} page
  */
 async function fastForwardAnimations( page ) {
-	return page.evaluate( () => {
+	return page.evaluate( async () => {
 		// Adapted from https://github.com/microsoft/playwright/blob/0a401b2d86a39df85e57ad30bcec9ef81618abd0/packages/playwright-core/src/server/screenshotter.ts#L174
 		document.getAnimations().forEach( ( animation ) => {
 			if ( animation.playbackRate === 0 || !animation.effect ) {
@@ -21,6 +21,15 @@ async function fastForwardAnimations( page ) {
 			} else {
 				animation.cancel();
 			}
+		} );
+
+		// Wait until the next frame before resolving.
+		return new Promise( ( resolve ) => {
+			requestAnimationFrame( () => {
+				requestAnimationFrame( () => {
+					resolve();
+				} );
+			} );
 		} );
 	} );
 }

--- a/src/engine-scripts/puppet/jsReady.js
+++ b/src/engine-scripts/puppet/jsReady.js
@@ -5,9 +5,6 @@
  * @param {import("puppeteer").Page} page
  */
 module.exports = async ( page ) => {
-	await page.emulateMediaFeatures( [
-		{ name: 'prefers-reduced-motion', value: 'reduce' }
-	] );
 	await page.evaluate( async () => {
 		// eslint-disable-next-line no-undef
 		const skin = mw.config.get( 'skin' );

--- a/src/engine-scripts/puppet/menuState.js
+++ b/src/engine-scripts/puppet/menuState.js
@@ -33,7 +33,7 @@ const menuState = async ( page, buttonSelector, isClosed ) => {
 	}, buttonSelector, isClosed );
 
 	// Vector-2022 menus currently have transition animations when opened.
-	fastForwardAnimations( page );
+	await fastForwardAnimations( page );
 };
 
 module.exports = menuState;


### PR DESCRIPTION
Unfortunately, the `transition-duration` in
Ie1c6c1ba7263c232d874263fdae7427a5ec489f6 is causing elements to behave in an
unpredictable manner. Removing the `prefers-reduced-motion` is now more
stable/predictable than using it.