### PR TITLE
Add 500ms delay for mobile

### DIFF
--- a/configMobile.js
+++ b/configMobile.js
@@ -28,7 +28,8 @@ const scenarios = tests.map( ( test ) => {
 	return Object.assign( {
 		selectors: [ 'viewport' ]
 	}, test, {
-		url: `${BASE_URL}${test.path}`
+		url: `${BASE_URL}${test.path}`,
+		delay: 500
 	} );
 } );
 


### PR DESCRIPTION
These delays are brutal for performance, but they help reduce the flakyness of
the sidebar.

Will remove once the reason for the brittle sidebar is determined