### PR TITLE
Fix flaky sidebar

### DIFF
--- a/configMobile.js
+++ b/configMobile.js
@@ -28,8 +28,7 @@ const scenarios = tests.map( ( test ) => {
 	return Object.assign( {
 		selectors: [ 'viewport' ]
 	}, test, {
-		url: `${BASE_URL}${test.path}`,
-		delay: 500
+		url: `${BASE_URL}${test.path}`
 	} );
 } );
 

--- a/src/engine-scripts/puppet/menuState.js
+++ b/src/engine-scripts/puppet/menuState.js
@@ -17,13 +17,7 @@ const menuState = async ( page, buttonSelector, isClosed ) => {
 		const isOpen = checkbox.checked;
 
 		const toggle = () => {
-			if ( isCheckbox ) {
-				btn.checked = !btn.checked;
-			} else {
-				btn.dispatchEvent(
-					new Event( 'click' )
-				);
-			}
+			btn.click();
 		};
 		if ( isExpectedClosed && isOpen ) {
 			toggle();


### PR DESCRIPTION
`dispatchEvent('click')` won't work as desired on label elements unless an event
handler is attached like checkboxHack.js adds. Because the menuState code could
execute before the checkboxHack.js code executed, a race condition was possible
where the mobile sidebar failed to show. Using `.click` instead avoids this race
condition.