### PR TITLE
Fix merge conflict side effects

### DIFF
--- a/src/checkoutPatch.js
+++ b/src/checkoutPatch.js
@@ -113,7 +113,11 @@ async function processQueue( changeQueue, repos ) {
 		commands.push(
 			`cd ${path} && 
 			git fetch origin ${change.revisions[ change.current_revision ].ref} && 
-			git rebase --onto HEAD origin/${change.branch} ${change.current_revision}`
+			{ git rebase --onto HEAD origin/${change.branch} ${change.current_revision} || {
+				e=$?
+				rm -fr .git/rebase-apply
+				exit $e
+			} }`
 		);
 
 		/** @type {RelatedChange[]} */


### PR DESCRIPTION
Previously when running a test command after running `./pixel.js test -c
<change-id>` that had a merge conflict, an error would throw complaning
that a rebase was in progress. To prevent this error, remove the
rebase-apply directory if the rebase fails.