### PR TITLE
Pin mariadb version to 10.6.7

### DIFF
--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -1,3 +1,3 @@
-FROM mariadb
+FROM mariadb:10.6.7
 
 RUN apt-get update && apt-get install curl -y


### PR DESCRIPTION
The seed data is meant to work with a specific version of mariadb and can
possibly break if another image version is used so pin the appropriate version.