### PR TITLE
Remove my_wiki_session cookie

### DIFF
--- a/src/engine-scripts/cookies.json
+++ b/src/engine-scripts/cookies.json
@@ -10,9 +10,5 @@
 	{
 		"name": "my_wikiUserName",
 		"value": "Admin"
-	},
-	{
-		"name": "my_wiki_session",
-		"value": "q435sohpicv4mf17oas491ub9pmof21b"
 	}
 ]


### PR DESCRIPTION
As a result of a change in login logic from
I3a76b67aa51159ebf0195db15cf7c34e00a64a2e, passing the my_wiki_session
cookie prevents the login scenarios from working correctly. Removing
this cookies, apparently allows the scenarios to continue working.