### PR TITLE
Set timeout for push job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,6 +13,7 @@ jobs:
   build:
     name: Lint, test, and run visual regression tests
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
     - name: Checkout branch
       uses: actions/checkout@v3


### PR DESCRIPTION
Since github actions CI have a 2000 minute limit [1], set a timeout so this limit is
not exceeded.

[1] https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions
