### PR TITLE
Convert duplicate Talk:Test from vector-2022 to vector

### DIFF
--- a/config.js
+++ b/config.js
@@ -57,9 +57,9 @@ const tests = [
 		path: '/w/index.php?title=Test&action=history&useskin=vector'
 	},
 	{
-		label: 'Talk:Test (#vector-2022)',
+		label: 'Talk:Test (#vector)',
 		delay: 1500,
-		path: '/wiki/Talk:Test'
+		path: '/wiki/Talk:Test?useskin=vector'
 	},
 	{
 		label: 'Tree (#vector)',


### PR DESCRIPTION
I think this was a typo but was causing two Talk:Test tests to run
on vector-2022.