### PR TITLE
Change default configuration to reflect moderator tools change

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -253,3 +253,13 @@ $wgVirtualRestConfig['modules']['parsoid'] = [
 $wgVectorTableOfContents = [
 	"default" => true,
 ];
+
+// For origin/wmf/1.39.0-wmf.14 against master.
+// https://phabricator.wikimedia.org/T308675
+// Can be removed when comparing wmf.15
+$wgMinervaOverflowInPageActions = [
+	"base" => false,
+	"beta" => false,
+	"amc" => true,
+	"loggedin" => true
+];


### PR DESCRIPTION
In T308675 a change was made to Minerva. This results in false
positives in our reports, so let's fix those

Since the Echo change is critical to QA I think it makes sense to update this in Pixel to reduce the noise level, what do you think?
