### PR TITLE
Rename config.js to configDesktop.js and fix linting errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ docker builder prune
 
 ### Changing or adding tests
 
-All tests are located in [config.js](config.js) and follow
-BackstopJS conventions. For more info on how to change or add tests, please
-refer to the [BackstopJS](https://github.com/garris/BackstopJS) README.
+All tests are located in config files in the root directory (e.g.
+configDesktop.js) and follow BackstopJS conventions. For more info on how to
+change or add tests, please refer to the
+[BackstopJS](https://github.com/garris/BackstopJS) README.
 
 Scenarios for mobile site are defined in configMobile.js.
 

--- a/configDesktop.js
+++ b/configDesktop.js
@@ -111,9 +111,9 @@ module.exports = {
 	scenarios,
 	paths: {
 		// eslint-disable-next-line camelcase
-		bitmaps_reference: 'report/reference-screenshots',
+		bitmaps_reference: 'report/reference-screenshots-desktop',
 		// eslint-disable-next-line camelcase
-		bitmaps_test: 'report/test-screenshots',
+		bitmaps_test: 'report/test-screenshots-desktop',
 		// eslint-disable-next-line camelcase
 		engine_scripts: 'src/engine-scripts',
 		// eslint-disable-next-line camelcase

--- a/configEcho.js
+++ b/configEcho.js
@@ -1,6 +1,18 @@
-const config = require( './config.js' );
+const configDesktop = require( './configDesktop.js' );
 
 const BASE_URL = process.env.MW_SERVER;
+
+/**
+ * @typedef {Object} BaseScenario
+ * @property {string} label
+ * @property {string} path
+ * @property {string[]} hashtags
+ */
+
+/**
+ * @callback BaseScenarioCallback
+ * @param {BaseScenario} baseScenario
+ */
 
 /**
  * Be careful when expanding the list of tests here.
@@ -9,7 +21,7 @@ const BASE_URL = process.env.MW_SERVER;
  * - Vector 2022 skin (mobile + tablet + desktop + desktop wide)
  * - Minerva skin (mobile + tablet + desktop + desktop wide)
  */
-const baseScenarios = [
+const baseScenarios = /** @type {BaseScenario[]} */ ( [
 	{
 		label: 'Echo smoke test with 0 notifications',
 		path: '/wiki/Test',
@@ -39,15 +51,15 @@ const baseScenarios = [
 		path: '/wiki/Test',
 		hashtags: [ '#echo-drawer' ]
 	}
-];
+] );
 
 /**
  * Creates a list of tests with the given query string and hashtags.
  *
- * @param {Array} hashtags additional hashtags
+ * @param {string[]} hashtags additional hashtags
  * @param {string} queryString to add to URL.
  * @param {Object} additionalConfig
- * @return {Array} of scenarios.
+ * @return {BaseScenarioCallback} of scenarios.
  */
 const makeScenarios = ( hashtags, queryString, additionalConfig = {} ) => {
 	return ( test ) => {
@@ -66,8 +78,8 @@ const makeScenarios = ( hashtags, queryString, additionalConfig = {} ) => {
 /**
  * Expands the list of tests so there is one for mobile and one for desktop.
  *
- * @param {Array} tests
- * @return {Array}
+ * @param {BaseScenario[]} tests
+ * @return {import("backstopjs").Scenario[]}
  */
 const makeMobileAndDesktopScenarios = ( tests ) => {
 	return tests.map(
@@ -101,9 +113,9 @@ const makeMobileAndDesktopScenarios = ( tests ) => {
 
 const scenarios = makeMobileAndDesktopScenarios( baseScenarios );
 
-module.exports = Object.assign( {}, config, {
+module.exports = Object.assign( {}, configDesktop, {
 	scenarios,
-	paths: Object.assign( {}, config.paths, {
+	paths: Object.assign( {}, configDesktop.paths, {
 		// eslint-disable-next-line camelcase
 		bitmaps_reference: 'report/reference-screenshots-echo',
 		// eslint-disable-next-line camelcase

--- a/configMobile.js
+++ b/configMobile.js
@@ -1,4 +1,4 @@
-const config = require( './config.js' );
+const configDesktop = require( './configDesktop.js' );
 
 const BASE_URL = process.env.MW_SERVER;
 const tests = [
@@ -32,13 +32,13 @@ const scenarios = tests.map( ( test ) => {
 	} );
 } );
 
-module.exports = Object.assign( {}, config, {
+module.exports = Object.assign( {}, configDesktop, {
 	scenarios,
-	paths: Object.assign( {}, config.paths, {
+	paths: Object.assign( {}, configDesktop.paths, {
 		// eslint-disable-next-line camelcase
 		bitmaps_reference: 'report/reference-screenshots-mobile',
 		// eslint-disable-next-line camelcase
-		bitmaps_test: 'report/test-screenshots',
+		bitmaps_test: 'report/test-screenshots-mobile',
 		// eslint-disable-next-line camelcase
 		html_report: 'report/mobile'
 	} )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
       - .env
     volumes:
       - ./context.json:/pixel/context.json
-      - ./config.js:/pixel/config.js
+      - ./configDesktop.js:/pixel/configDesktop.js
       - ./configEcho.js:/pixel/configEcho.js
       - ./configMobile.js:/pixel/configMobile.js
       - ./src:/pixel/src

--- a/pixel.js
+++ b/pixel.js
@@ -68,7 +68,7 @@ const getGroupConfig = ( groupName ) => {
 		case 'echo':
 			return 'configEcho.js';
 		case 'desktop':
-			return 'config.js';
+			return 'configDesktop.js';
 		case 'mobile':
 			return 'configMobile.js';
 		default:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"include": [
 		"src",
-		"config.js"
+		"config*.js"
 	],
 	"exclude": [
 		"src/engine-scripts",


### PR DESCRIPTION
* Rename config.js to follow the conventions set by other configs.
* Revises reference and screenshot desktop folder names as well
* Edit tsconfig to check all config files
* Fix configEcho linting errors as a result of the preceding point