### PR TITLE
Add clean and stop commands to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ If you want to run the mobile visual regression test suite pass the `--group mob
 If you want to stop all of Pixel's services, run:
 
 ```
-npm stop
+./pixel.js stop
 ```
 
 ### Cleanup
@@ -101,7 +101,7 @@ issues with the containers you just want to throw away everything and start
 Pixel with a clean slate. To do that, run:
 
 ```
-npm run clean
+./pixels.js clean
 ```
 
 Note that if you've made changes to LocalSettings.php and want to reset that,

--- a/package.json
+++ b/package.json
@@ -2,9 +2,6 @@
 	"private": true,
 	"name": "pixel",
 	"scripts": {
-		"start": "docker compose up -d",
-		"stop": "docker compose down",
-		"clean": "docker compose down --rmi all -v --remove-orphans",
 		"bash": "docker compose exec mediawiki bash",
 		"db:save": "docker compose run -v $(pwd)/backups:/backups database tar cvfz /backups/database_$(date '+%Y-%m-%d_%H-%M-%S%z(%Z)').tar.gz var/lib/mysql",
 		"lint": "eslint --cache .",

--- a/pixel.js
+++ b/pixel.js
@@ -20,6 +20,17 @@ function getComposeOpts( opts ) {
 	];
 }
 
+/**
+ * Removes all images, containers, networks, and volumes associated with Pixel.
+ * This will often be used after updates to the Docker images and/or volumes and
+ * will reset everything so that Pixel starts with a clean slate.
+ *
+ * @return {Promise}
+ */
+async function cleanCommand() {
+	await batchSpawn.spawn( 'docker', [ 'compose', ...getComposeOpts( [ 'down', '--rmi', 'all', '--volumes', '--remove-orphans' ] ) ] );
+}
+
 let context;
 if ( fs.existsSync( CONTEXT_PATH ) ) {
 	context = JSON.parse( fs.readFileSync( CONTEXT_PATH ).toString() );
@@ -183,6 +194,23 @@ function setupCli() {
 		.option( ...groupOpt )
 		.action( ( opts ) => {
 			processCommand( 'test', opts );
+		} );
+
+	program
+		.command( 'stop' )
+		.description( 'Stops all Docker containers associated with Pixel' )
+		.action( async () => {
+			await batchSpawn.spawn(
+				'docker',
+				[ 'compose', ...getComposeOpts( [ 'stop' ] ) ]
+			);
+		} );
+
+	program
+		.command( 'clean' )
+		.description( 'Removes all containers, images, networks, and volumes associated with Pixel so that it can start with a clean slate. If Pixel is throwing errors, try running this command.' )
+		.action( async () => {
+			await cleanCommand();
 		} );
 
 	program.parse();


### PR DESCRIPTION
The clean command which was previous an npm script (`npm run clean`) and
destroys all containers, images, and volumes related to Pixel has proven to be
useful and should be promoted as part of the CLI API. The stop command which
stops all containers follows similar logic.

Both of these will become critical commands when Pixel is installed as an npm
module.

To destroy all containers, images, volumes related to Pixel:

```
./pixel.js clean
```

To stop all containers related to Pixel:
```
./pixel.js stop
```

Additionally, removes corresponding npm commands since these are now part of the
CLI.