### PR TITLE
Add ability to reset the database

### DIFF
--- a/Dockerfile.database
+++ b/Dockerfile.database
@@ -1,3 +1,13 @@
 FROM mariadb:10.6.7
 
-RUN apt-get update && apt-get install curl -y
+COPY src/seedDb.sh /docker-entrypoint-initdb.d/
+
+ARG database="database_2022-06-13_12-27-44-0600(MDT).tar.gz"
+
+RUN apt-get update && apt-get install -y \
+	curl \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& mkdir -p /var/lib/mysql_backup \
+	&& curl -SL "https://nicholasray.github.io/pixel-seed-data/$database" \
+	| tar -C /var/lib/mysql_backup --strip-components=3 -xzv \
+	&& chown mysql:mysql /var/lib/mysql_backup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,10 +41,10 @@ services:
       - dbdata:/var/lib/mysql
       - ./src/seedDb.sh:/docker-entrypoint-initdb.d/seedDb.sh
     healthcheck:
-      test: [ CMD, mysqladmin, ping, -h, localhost ]
-      interval: 10s
+      test: [ CMD, mysql, my_wiki, -e, status ]
+      interval: 1s
       timeout: 5s
-      retries: 10
+      retries: 20
   visual-regression:
     network_mode: host
     image: backstopjs/backstopjs:6.0.4

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"name": "pixel",
 	"scripts": {
 		"bash": "docker compose exec mediawiki bash",
-		"db:save": "docker compose run -v $(pwd)/backups:/backups database tar cvfz /backups/database_$(date '+%Y-%m-%d_%H-%M-%S%z(%Z)').tar.gz var/lib/mysql",
+		"db:save": "docker compose exec database mysql -e 'SET GLOBAL innodb_fast_shutdown=0;' && docker compose stop database && docker compose run --rm -v $(pwd)/backups:/backups database tar cvfz /backups/database_$(date '+%Y-%m-%d_%H-%M-%S%z(%Z)').tar.gz var/lib/mysql && docker compose up -d database",
 		"lint": "eslint --cache .",
 		"test": "npm -s run lint && tsc && npm run test:unit",
 		"test:unit": "jest",

--- a/src/seedDb.sh
+++ b/src/seedDb.sh
@@ -1,4 +1,2 @@
 #!/usr/bin/env bash
-
-curl "https://nicholasray.github.io/pixel-seed-data/database_2022-05-26_13-03-37-0700(PDT).tar.gz" -o var/lib/mysql/database.tar.gz 
-tar -xvf var/lib/mysql/database.tar.gz
+rsync -a /var/lib/mysql_backup/ /var/lib/mysql


### PR DESCRIPTION
The ability to reset the database before a test group runs can be necessary when
using previous branch (e.g. when using the `-b` flag) as that code may assume an
older database schema structure that the database may not have.

Resetting the db will also become critical when tests are introduced that make
changes to the database (e.g. tests that edit an article ). Providing this flag
enables the ability for each test group to be completely isolated from the side
effects that another test group may cause.

Additionally:

* Update database seed file to `database_2022-06-13_12-27-44-0600(MDT).tar.gz`
to fix `crash` messages appearing in the mysql logs.

* Revise `db:save` npm script to enable "slow shutdown" of mysql prior to taking a physical backup. Mysql states this is needed in their docs [1]

* Revise healthcheck logic in docker compose after noticing the healthcheck
reporting that the db was healthy when it wasn't accepting any connections yet.
Relying on a `status` query for the my_wiki should be more reliable.

[1] https://dev.mysql.com/doc/refman/8.0/en/innodb-backup.html