### PR TITLE
Increase table and desktop breakpoints by 1 pixel

### DIFF
--- a/viewports.js
+++ b/viewports.js
@@ -1,9 +1,3 @@
-const VIEWPORT_DESKTOP_WIDE = {
-	label: 'desktop-wide',
-	width: 1792,
-	height: 900
-};
-
 const VIEWPORT_PHONE = {
 	label: 'phone',
 	width: 320,
@@ -12,13 +6,19 @@ const VIEWPORT_PHONE = {
 
 const VIEWPORT_TABLET = {
 	label: 'tablet',
-	width: 720,
+	width: 721,
 	height: 768
 };
 
 const VIEWPORT_DESKTOP = {
 	label: 'desktop',
-	width: 1000,
+	width: 1001,
+	height: 900
+};
+
+const VIEWPORT_DESKTOP_WIDE = {
+	label: 'desktop-wide',
+	width: 1792,
 	height: 900
 };
 


### PR DESCRIPTION
These were leading to too many failures that only happened when the
viewport was either exactly 720px or 1000px wide. These peculiarities
are caused by the way we mix min-width and max-width media queries
(T310536) and are actual problems, but there are bigger fish to fry than
to base the tests on these problematic viewport widths.