### PR TITLE
Fix "‘node’: No such file or directory" error

### DIFF
--- a/Dockerfile.mediawiki
+++ b/Dockerfile.mediawiki
@@ -1,9 +1,7 @@
-FROM node:16.15.0-buster AS node
 FROM docker-registry.wikimedia.org/dev/buster-php72-fpm:2.0.0-s1
 
-COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
-COPY --from=node /usr/local/bin/node /usr/local/bin/node
-RUN ln -s /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+	&& apt-get install -y nodejs
 
 COPY src /src
 COPY repositories.json /repositories.json


### PR DESCRIPTION
This error has occurred in the past, and I thought had been fixed, but it
occurred recently on my new macbook m1 so this is another attempt to fix it. My
guess is that something wrong was happening with the Docker multistage build.
The easiest way to avoid this is to not use a multistage build and instead
install node from nodesource. Hopefully, this resolves this error.