### PR TITLE
Update LocalSettings.php to ensure extension added portlet link has the correct classes

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -215,7 +215,7 @@ $wgSharedTables = [ 'user' ]; // Note that 'user_properties' is not included.
 $wgHooks['SkinTemplateNavigation::Universal'][] = function ( $skinTemplate, &$links ) {
         $links['user-menu']['extension'] = [
                 'link-class' => [ 'ext' ],
-                'class' => [ 'ext' ],
+                'class' => [ 'mw-ui-icon mw-ui-icon-before mw-ui-icon- mw-ui-icon-wikimedia-ext' ],
                 'text' => 'I am an extension',
                 'href' => 'https://mediawiki.org'
         ];


### PR DESCRIPTION
The portlet link added by extension defined in LocalSettings.php doesn't include the correct icon classes. This is causing a Pixel false positive in the following patch: https://gerrit.wikimedia.org/r/c/mediawiki/skins/Vector/+/780893