### PR TITLE
Fix update command

### DIFF
--- a/pixel.js
+++ b/pixel.js
@@ -257,7 +257,7 @@ function setupCli() {
 		.action( async () => {
 			await batchSpawn.spawn(
 				'git',
-				[ '-C', __dirname, 'fetch', 'origin', 'main:main' ]
+				[ '-C', __dirname, 'fetch', '-u', 'origin', 'main:main' ]
 			);
 			await cleanCommand();
 		} );


### PR DESCRIPTION
Before this commit, the update command would throw an error if you were
on the main brach because of the default behavior of git fetch. This
should avoid that error.