### PR TITLE
Set eslint warning limit to 0 and fix lint errors

### DIFF
--- a/configDesktop.js
+++ b/configDesktop.js
@@ -118,8 +118,9 @@ const tests = [
 ];
 
 const scenarios = tests.map( ( test ) => {
-	// On mobile, short pages will cause false positives on some patchsets e.g. the switchover to grid CSS.
-	// To avoid this use the viewport selector when not defined.
+	// On mobile, short pages will cause false positives on some patchsets e.g.
+	// the switchover to grid CSS.  To avoid this use the viewport selector when
+	// not defined.
 	const isShortPage = [
 		'/wiki/Main_Page',
 		'/wiki/Tree',

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"scripts": {
 		"bash": "docker compose exec mediawiki bash",
 		"db:save": "docker compose exec database mysql -e 'SET GLOBAL innodb_fast_shutdown=0;' && docker compose stop database && docker compose run --rm -v $(pwd)/backups:/backups database tar cvfz /backups/database_$(date '+%Y-%m-%d_%H-%M-%S%z(%Z)').tar.gz var/lib/mysql && docker compose up -d database",
-		"lint": "eslint --cache .",
+		"lint": "eslint --max-warnings 0 --cache .",
 		"test": "npm -s run lint && tsc && npm run test:unit",
 		"test:unit": "jest",
 		"pre-commit": "[ \"${PRE_COMMIT:-1}\" -eq 0 ] || npm -s t"


### PR DESCRIPTION
Some lint warning were sneaking through as the tests weren't failing.
Set the warning limit to 0 to prevent this and fix the lint error.